### PR TITLE
update DEFINE_SEMAPHORE usage for linux 6.4+

### DIFF
--- a/thinkpad_ec.c
+++ b/thinkpad_ec.c
@@ -90,8 +90,10 @@ static u64 prefetch_jiffies;                      /* time of prefetch, or: */
 /* Locking: */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,37)
 static DECLARE_MUTEX(thinkpad_ec_mutex);
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
 static DEFINE_SEMAPHORE(thinkpad_ec_mutex);
+#else
+static DEFINE_SEMAPHORE(thinkpad_ec_mutex, 1);
 #endif
 
 /* Kludge in case the ACPI DSDT reserves the ports we need. */

--- a/tp_smapi.c
+++ b/tp_smapi.c
@@ -111,8 +111,10 @@ static unsigned short smapi_port;  /* APM control port, normally 0xB2 */
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,37)
 static DECLARE_MUTEX(smapi_mutex);
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
 static DEFINE_SEMAPHORE(smapi_mutex);
+#else
+static DEFINE_SEMAPHORE(smapi_mutex, 1);
 #endif
 
 /**


### PR DESCRIPTION
Linux changed the DEFINE_SEMAPHORE macro in
48380368dec14859723b9e3fbd43e042638d9a76, making it take two parameters instead of one. Pass an explicit 1 as on 6.4+.